### PR TITLE
fix: correct card-box-cg submodule source and pointer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "card-box-cg"]
 	path = card-box-cg
-	url = https://github.com/Intelligent-Internet/card-box-cg.git
+	url = https://github.com/Intelligent-Internet/CG-Cardbox.git


### PR DESCRIPTION
修正 `card-box-cg` submodule 的 URL 与 gitlink，恢复到远端可获取的提交。

Closes #4
