### PR TITLE
fix(ci): scope GitHub release sync to the target repository

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -269,6 +269,7 @@ jobs:
       - name: Sync GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: Intelligent-Internet/CommonGround
           RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
         run: |
           set -euo pipefail
@@ -296,18 +297,18 @@ jobs:
           }
 
           ensure_release() {
-            if retry 3 5 gh release view "$RELEASE_TAG" --json url >/dev/null; then
+            if retry 3 5 gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json url >/dev/null; then
               echo "Release ${RELEASE_TAG} already exists."
               return 0
             fi
 
-            retry 3 5 gh release create "$RELEASE_TAG" --verify-tag --generate-notes
+            retry 3 5 gh release create "$RELEASE_TAG" --repo "$GH_REPO" --verify-tag --generate-notes
           }
 
           ensure_release
 
           mapfile -t existing_assets < <(
-            retry 3 5 gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name'
+            retry 3 5 gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.assets[].name'
           )
 
           for asset in dist/*.tar.gz dist/*.whl; do
@@ -317,5 +318,5 @@ jobs:
               continue
             fi
 
-            retry 3 5 gh release upload "$RELEASE_TAG" "$asset"
+            retry 3 5 gh release upload "$RELEASE_TAG" --repo "$GH_REPO" "$asset"
           done


### PR DESCRIPTION
## Summary

Fix the release sync job so it does not depend on a local `.git` checkout to resolve the repository.

## What changed

- add `GH_REPO=Intelligent-Internet/CommonGround` to `sync_github_release`
- pass `--repo "$GH_REPO"` to all `gh release` commands:
  - `gh release view`
  - `gh release create`
  - `gh release upload`

## Why

The `sync_github_release` job only downloads release artifacts and does not run `actions/checkout`. As a result, the job workspace is not a git repository, and `gh release ...` fails with:

```text
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

Scoping the `gh` commands explicitly to `Intelligent-Internet/CommonGround` removes that dependency and allows the release sync step to run correctly without a checkout.

## Validation

- verified the workflow diff only touches `.github/workflows/publish.yml`
- ran `git diff --check`
